### PR TITLE
Fix cooldown duration variance calculation

### DIFF
--- a/src/engine/Cooldown.java
+++ b/src/engine/Cooldown.java
@@ -66,6 +66,6 @@ public class Cooldown {
 		if (this.variance != 0)
 			this.duration = (this.milliseconds - this.variance)
 					+ (int) (Math.random()
-							* (this.milliseconds + this.variance));
+							* (this.variance * 2));
 	}
 }


### PR DESCRIPTION
### Changes
- Fixed `duration` calculation in `reset()` method.
- Previously, `Math.random()` was multiplied by `milliseconds + variance`, which caused incorrect variance handling.
- Now correctly uses `variance * 2` to randomize `duration` between (milliseconds - variance) and (milliseconds + variance).

### Why
- Ensures the cooldown duration properly reflects the intended variance range.

Please let me know if any changes are needed.  
Thank you! 😀